### PR TITLE
Add LED driver unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,3 +154,4 @@ jobs:
           cd firmware/tests/build
           ./test_nmea_parser
           ./test_button_handler
+          ./test_led_driver

--- a/firmware/tests/CMakeLists.txt
+++ b/firmware/tests/CMakeLists.txt
@@ -32,3 +32,14 @@ target_include_directories(test_button_handler PRIVATE
     ${CMAKE_SOURCE_DIR}/../main
 )
 target_link_libraries(test_button_handler PRIVATE Catch2::Catch2WithMain)
+
+add_executable(test_led_driver test_led_driver.cpp
+    src/gpio_mock.cpp
+    ${CMAKE_SOURCE_DIR}/../main/gpio_driver.cpp
+    ${CMAKE_SOURCE_DIR}/../main/led_driver.cpp
+)
+target_include_directories(test_led_driver PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/../main
+)
+target_link_libraries(test_led_driver PRIVATE Catch2::Catch2WithMain)

--- a/firmware/tests/include/driver/gpio.h
+++ b/firmware/tests/include/driver/gpio.h
@@ -11,8 +11,36 @@ typedef enum {
     GPIO_MODE_DISABLE
 } gpio_mode_t;
 
+typedef enum {
+    GPIO_PULLUP_DISABLE = 0,
+    GPIO_PULLUP_ENABLE = 1
+} gpio_pullup_t;
+
+typedef enum {
+    GPIO_PULLDOWN_DISABLE = 0,
+    GPIO_PULLDOWN_ENABLE = 1
+} gpio_pulldown_t;
+
+typedef enum {
+    GPIO_INTR_DISABLE = 0,
+    GPIO_INTR_ANYEDGE = 2,
+    GPIO_INTR_NEGEDGE = 3,
+    GPIO_INTR_POSEDGE = 4
+} gpio_int_type_t;
+
 typedef int gpio_num_t;
-typedef uint32_t gpio_config_t;
+
+#define GPIO_PULLUP_DISABLE GPIO_PULLUP_DISABLE
+#define GPIO_PULLDOWN_DISABLE GPIO_PULLDOWN_DISABLE
+#define GPIO_INTR_DISABLE GPIO_INTR_DISABLE
+
+typedef struct {
+    uint64_t pin_bit_mask;
+    gpio_mode_t mode;
+    gpio_pullup_t pull_up_en;
+    gpio_pulldown_t pull_down_en;
+    gpio_int_type_t intr_type;
+} gpio_config_t;
 
 #define GPIO_NUM_0  ((gpio_num_t)0)
 #define GPIO_NUM_1  ((gpio_num_t)1)

--- a/firmware/tests/test_led_driver.cpp
+++ b/firmware/tests/test_led_driver.cpp
@@ -6,7 +6,6 @@
 
 TEST_CASE("LedDriver state transitions", "[led]") {
     mock_gpio::reset_gpio_mock();
-    mock_esp_timer::reset_timer_mock();
 
     SECTION("on() sets GPIO high") {
         LedDriver led(GPIO_NUM_8);


### PR DESCRIPTION
## Summary
- Add unit tests for LedDriver (9 assertions covering on/off/toggle/state)
- Expand GPIO mock with pullup/pulldown/intr types and proper struct definition
- Add test_led_driver to CI workflow
- Remove unnecessary timer mock reset from LED test

## Testing
- Host tests pass: 43 (NMEA) + 4 (Button) + 9 (LED) = 56 assertions