### PR TITLE
Add NVS config storage for tracker settings

### DIFF
--- a/docs/hardware/PLAN.md
+++ b/docs/hardware/PLAN.md
@@ -481,7 +481,7 @@ def geofences():
 | 4 | LoRa SX1262 driver | ✅ Done (PR #6, PR #7) |
 | 4 | BLE GATT server | ✅ Done (PR #9) |
 | 4 | LIS3DH accelerometer | ✅ Done (PR #10) |
-| 5 | State machine | Pending |
+| 5 | State machine | ✅ Done (PR #11) |
 | 6 | NVS config storage | Pending |
 | 7 | Motion-aware sleep | Pending |
 | 8 | Geofencing | Pending |

--- a/firmware/main/config.cpp
+++ b/firmware/main/config.cpp
@@ -1,0 +1,275 @@
+#include "config.hpp"
+#include "esp_log.h"
+
+static const char* TAG = "config";
+
+esp_err_t Config::init() {
+    esp_err_t ret = nvs_flash_init();
+    if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+        ESP_LOGW(TAG, "NVS partition was truncated, erasing and reinitializing");
+        ret = nvs_flash_erase();
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to erase NVS: %s", esp_err_to_name(ret));
+            return ret;
+        }
+        ret = nvs_flash_init();
+    }
+    return ret;
+}
+
+esp_err_t Config::load(TrackerConfig& config) {
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NS, NVS_READONLY, &handle);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to open NVS namespace: %s", esp_err_to_name(ret));
+        return ret;
+    }
+
+    ret = get_u32(handle, "device_id", config.device_id);
+    if (ret != ESP_OK) {
+        config.device_id = DEFAULT_DEVICE_ID;
+    }
+
+    ret = get_u32(handle, "sleep_interval", config.sleep_interval_ms);
+    if (ret != ESP_OK) {
+        config.sleep_interval_ms = DEFAULT_SLEEP_INTERVAL_MS;
+    }
+
+    ret = get_u32(handle, "stationary_interval", config.stationary_interval_ms);
+    if (ret != ESP_OK) {
+        config.stationary_interval_ms = DEFAULT_STATIONARY_INTERVAL_MS;
+    }
+
+    ret = get_u8(handle, "tx_power", config.tx_power);
+    if (ret != ESP_OK) {
+        config.tx_power = DEFAULT_TX_POWER;
+    }
+
+    ret = get_u8(handle, "spreading_factor", config.spreading_factor);
+    if (ret != ESP_OK) {
+        config.spreading_factor = DEFAULT_SPREADING_FACTOR;
+    }
+
+    ret = get_str(handle, "device_name", config.device_name, sizeof(config.device_name));
+    if (ret != ESP_OK) {
+        strlcpy(config.device_name, DEFAULT_DEVICE_NAME, sizeof(config.device_name));
+    }
+
+    nvs_close(handle);
+    ESP_LOGI(TAG, "Config loaded: device_id=0x%08x, sleep=%ums, stationary=%ums, tx_power=%u, sf=%u",
+              config.device_id, config.sleep_interval_ms, config.stationary_interval_ms,
+              config.tx_power, config.spreading_factor);
+    return ESP_OK;
+}
+
+esp_err_t Config::save(const TrackerConfig& config) {
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NS, NVS_READWRITE, &handle);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to open NVS namespace: %s", esp_err_to_name(ret));
+        return ret;
+    }
+
+    ret = set_u32(handle, "device_id", config.device_id);
+    if (ret != ESP_OK) {
+        goto cleanup;
+    }
+
+    ret = set_u32(handle, "sleep_interval", config.sleep_interval_ms);
+    if (ret != ESP_OK) {
+        goto cleanup;
+    }
+
+    ret = set_u32(handle, "stationary_interval", config.stationary_interval_ms);
+    if (ret != ESP_OK) {
+        goto cleanup;
+    }
+
+    ret = set_u8(handle, "tx_power", config.tx_power);
+    if (ret != ESP_OK) {
+        goto cleanup;
+    }
+
+    ret = set_u8(handle, "spreading_factor", config.spreading_factor);
+    if (ret != ESP_OK) {
+        goto cleanup;
+    }
+
+    ret = set_str(handle, "device_name", config.device_name);
+    if (ret != ESP_OK) {
+        goto cleanup;
+    }
+
+    ret = nvs_commit(handle);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to commit NVS: %s", esp_err_to_name(ret));
+    } else {
+        ESP_LOGI(TAG, "Config saved successfully");
+    }
+
+cleanup:
+    nvs_close(handle);
+    return ret;
+}
+
+esp_err_t Config::get_device_id(uint32_t& device_id) {
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NS, NVS_READONLY, &handle);
+    if (ret != ESP_OK) {
+        return ret;
+    }
+    ret = get_u32(handle, "device_id", device_id);
+    nvs_close(handle);
+    return ret;
+}
+
+esp_err_t Config::set_device_id(uint32_t device_id) {
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NS, NVS_READWRITE, &handle);
+    if (ret != ESP_OK) {
+        return ret;
+    }
+    ret = set_u32(handle, "device_id", device_id);
+    nvs_close(handle);
+    return ret;
+}
+
+esp_err_t Config::get_sleep_interval(uint32_t& interval_ms) {
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NS, NVS_READONLY, &handle);
+    if (ret != ESP_OK) {
+        return ret;
+    }
+    ret = get_u32(handle, "sleep_interval", interval_ms);
+    nvs_close(handle);
+    return ret;
+}
+
+esp_err_t Config::set_sleep_interval(uint32_t interval_ms) {
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NS, NVS_READWRITE, &handle);
+    if (ret != ESP_OK) {
+        return ret;
+    }
+    ret = set_u32(handle, "sleep_interval", interval_ms);
+    nvs_close(handle);
+    return ret;
+}
+
+esp_err_t Config::get_stationary_interval(uint32_t& interval_ms) {
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NS, NVS_READONLY, &handle);
+    if (ret != ESP_OK) {
+        return ret;
+    }
+    ret = get_u32(handle, "stationary_interval", interval_ms);
+    nvs_close(handle);
+    return ret;
+}
+
+esp_err_t Config::set_stationary_interval(uint32_t interval_ms) {
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NS, NVS_READWRITE, &handle);
+    if (ret != ESP_OK) {
+        return ret;
+    }
+    ret = set_u32(handle, "stationary_interval", interval_ms);
+    nvs_close(handle);
+    return ret;
+}
+
+esp_err_t Config::get_tx_power(uint8_t& tx_power) {
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NS, NVS_READONLY, &handle);
+    if (ret != ESP_OK) {
+        return ret;
+    }
+    ret = get_u8(handle, "tx_power", tx_power);
+    nvs_close(handle);
+    return ret;
+}
+
+esp_err_t Config::set_tx_power(uint8_t tx_power) {
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NS, NVS_READWRITE, &handle);
+    if (ret != ESP_OK) {
+        return ret;
+    }
+    ret = set_u8(handle, "tx_power", tx_power);
+    nvs_close(handle);
+    return ret;
+}
+
+esp_err_t Config::get_spreading_factor(uint8_t& sf) {
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NS, NVS_READONLY, &handle);
+    if (ret != ESP_OK) {
+        return ret;
+    }
+    ret = get_u8(handle, "spreading_factor", sf);
+    nvs_close(handle);
+    return ret;
+}
+
+esp_err_t Config::set_spreading_factor(uint8_t sf) {
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NS, NVS_READWRITE, &handle);
+    if (ret != ESP_OK) {
+        return ret;
+    }
+    ret = set_u8(handle, "spreading_factor", sf);
+    nvs_close(handle);
+    return ret;
+}
+
+esp_err_t Config::get_device_name(char* name, size_t max_len) {
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NS, NVS_READONLY, &handle);
+    if (ret != ESP_OK) {
+        return ret;
+    }
+    ret = get_str(handle, "device_name", name, max_len);
+    nvs_close(handle);
+    return ret;
+}
+
+esp_err_t Config::set_device_name(const char* name) {
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NS, NVS_READWRITE, &handle);
+    if (ret != ESP_OK) {
+        return ret;
+    }
+    ret = set_str(handle, "device_name", name);
+    nvs_close(handle);
+    return ret;
+}
+
+esp_err_t Config::get_u32(nvs_handle_t handle, const char* key, uint32_t& value) {
+    return nvs_get_u32(handle, key, &value);
+}
+
+esp_err_t Config::set_u32(nvs_handle_t handle, const char* key, uint32_t value) {
+    return nvs_set_u32(handle, key, value);
+}
+
+esp_err_t Config::get_u8(nvs_handle_t handle, const char* key, uint8_t& value) {
+    return nvs_get_u8(handle, key, &value);
+}
+
+esp_err_t Config::set_u8(nvs_handle_t handle, const char* key, uint8_t value) {
+    return nvs_set_u8(handle, key, value);
+}
+
+esp_err_t Config::get_str(nvs_handle_t handle, const char* key, char* value, size_t max_len) {
+    size_t len = max_len;
+    esp_err_t ret = nvs_get_str(handle, key, value, &len);
+    if (ret == ESP_ERR_NVS_NOT_FOUND) {
+        strlcpy(value, DEFAULT_DEVICE_NAME, max_len);
+        return ESP_OK;
+    }
+    return ret;
+}
+
+esp_err_t Config::set_str(nvs_handle_t handle, const char* key, const char* value) {
+    return nvs_set_str(handle, key, value);
+}

--- a/firmware/main/config.hpp
+++ b/firmware/main/config.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <stdint.h>
+#include <string.h>
+#include "esp_err.h"
+#include "nvs_flash.h"
+#include "nvs.h"
+
+struct TrackerConfig {
+    uint32_t device_id;
+    uint32_t sleep_interval_ms;
+    uint32_t stationary_interval_ms;
+    uint8_t tx_power;
+    uint8_t spreading_factor;
+    char device_name[32];
+};
+
+class Config {
+public:
+    static esp_err_t init();
+    
+    static esp_err_t load(TrackerConfig& config);
+    static esp_err_t save(const TrackerConfig& config);
+    
+    static esp_err_t get_device_id(uint32_t& device_id);
+    static esp_err_t set_device_id(uint32_t device_id);
+    
+    static esp_err_t get_sleep_interval(uint32_t& interval_ms);
+    static esp_err_t set_sleep_interval(uint32_t interval_ms);
+    
+    static esp_err_t get_stationary_interval(uint32_t& interval_ms);
+    static esp_err_t set_stationary_interval(uint32_t interval_ms);
+    
+    static esp_err_t get_tx_power(uint8_t& tx_power);
+    static esp_err_t set_tx_power(uint8_t tx_power);
+    
+    static esp_err_t get_spreading_factor(uint8_t& sf);
+    static esp_err_t set_spreading_factor(uint8_t sf);
+    
+    static esp_err_t get_device_name(char* name, size_t max_len);
+    static esp_err_t set_device_name(const char* name);
+
+private:
+    static esp_err_t get_u32(nvs_handle_t handle, const char* key, uint32_t& value);
+    static esp_err_t set_u32(nvs_handle_t handle, const char* key, uint32_t value);
+    static esp_err_t get_u8(nvs_handle_t handle, const char* key, uint8_t& value);
+    static esp_err_t set_u8(nvs_handle_t handle, const char* key, uint8_t value);
+    static esp_err_t get_str(nvs_handle_t handle, const char* key, char* value, size_t max_len);
+    static esp_err_t set_str(nvs_handle_t handle, const char* key, const char* value);
+    
+    static constexpr char NVS_NS[] = "tracker_config";
+    static constexpr uint32_t DEFAULT_DEVICE_ID = 0x12345678;
+    static constexpr uint32_t DEFAULT_SLEEP_INTERVAL_MS = 300000;
+    static constexpr uint32_t DEFAULT_STATIONARY_INTERVAL_MS = 600000;
+    static constexpr uint8_t DEFAULT_TX_POWER = 22;
+    static constexpr uint8_t DEFAULT_SPREADING_FACTOR = 7;
+    static constexpr const char* DEFAULT_DEVICE_NAME = "PetTracker";
+};


### PR DESCRIPTION
## Summary
Add NVS (Non-Volatile Storage) config module for persisting tracker settings.

## Changes
- Add `config.hpp` with `TrackerConfig` struct and `Config` class API
- Add `config.cpp` with NVS read/write implementation
- Store: device_id, sleep_interval, stationary_interval, tx_power, spreading_factor, device_name
- Provide both bulk `load()`/`save()` and individual getter/setter APIs
- Defaults applied when NVS values are not set

## API
```cpp
struct TrackerConfig {
    uint32_t device_id;
    uint32_t sleep_interval_ms;
    uint32_t stationary_interval_ms;
    uint8_t tx_power;
    uint8_t spreading_factor;
    char device_name[32];
};

class Config {
public:
    static esp_err_t init();
    static esp_err_t load(TrackerConfig& config);
    static esp_err_t save(const TrackerConfig& config);
    // Individual getters/setters also available...
};
```

## Test Plan
- [ ] Build passes for ESP32S3
- [ ] Build passes for ESP32C6
- [ ] Unit tests pass