### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Check if firmware build is needed
   check-firmware-changed:


### PR DESCRIPTION
Potential fix for [https://github.com/gdellis/esp32-pet-tracker/security/code-scanning/5](https://github.com/gdellis/esp32-pet-tracker/security/code-scanning/5)

Add an explicit `permissions` block at the workflow root so all jobs inherit minimal token scopes unless overridden.  
Best fix here: in `.github/workflows/ci.yml`, insert:

- `permissions:`
  - `contents: read`

Place it near the top-level keys (e.g., after `concurrency` and before `jobs`). This preserves existing behavior while constraining token privileges. No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
