### PR TITLE
fix: UART cleanup, gpio error handling, std::optional battery reads

### DIFF
--- a/.clangd/config.yaml
+++ b/.clangd/config.yaml
@@ -5,4 +5,3 @@ CompileFlags:
     - "-fno-shrink-wrap"
     - "-fstrict-volatile-bitfields"
     - "-fno-tree-switch-conversion"
-    - "-fstrict-volatile-bitfields"

--- a/.clangd/config.yaml
+++ b/.clangd/config.yaml
@@ -1,0 +1,8 @@
+CompileFlags:
+  CompilationDatabase: firmware/build
+  Remove:
+    - "-mlongcalls"
+    - "-fno-shrink-wrap"
+    - "-fstrict-volatile-bitfields"
+    - "-fno-tree-switch-conversion"
+    - "-fstrict-volatile-bitfields"

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -25,13 +25,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        # with:
-          # persist-credentials: false
+        with:
+          persist-credentials: false
 
       - name: Run opencode
         uses: anomalyco/opencode/github@latest
         env:
-          # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
         with:
           model: ${{ secrets.OC_AGENT_MODEL || 'ollama-cloud/qwen3-coder:480b' }}
+          github_token: ${{ secrets.GITHUB_TOKEN }} 
+          

--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -35,10 +35,9 @@ jobs:
         uses: anomalyco/opencode/github@latest
         env:
           OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: ${{ secrets.REVIEW_AGENT_MODEL || 'ollama-cloud/qwen3-coder:480b' }}
-          use_github_token: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Review this pull request:
             - Verify github actions in PR passed  

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,16 @@
+{
+    "configurations": [
+        {
+            "name": "Linux",
+            "includePath": [
+                "${workspaceFolder}/**"
+            ],
+            "defines": [],
+            "compilerPath": "/usr/bin/gcc",
+            "cStandard": "c17",
+            "cppStandard": "gnu++17",
+            "intelliSenseMode": "linux-clang-x64"
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -6,7 +6,7 @@
                 "${workspaceFolder}/**"
             ],
             "defines": [],
-            "compilerPath": "/home/glenn/.espressif/tools/xtensa-esp-elf/esp-15.2.0_20251204/xtensa-esp32s3-elf/bin/xtensa-esp32s3-elf-gcc",
+            "compilerPath": "${env:HOME}/.espressif/tools/xtensa-esp-elf/esp-15.2.0_20251204/xtensa-esp32s3-elf/bin/xtensa-esp32s3-elf-gcc",
             "cStandard": "c17",
             "cppStandard": "gnu++17",
             "intelliSenseMode": "linux-clang-x64"

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -6,7 +6,7 @@
                 "${workspaceFolder}/**"
             ],
             "defines": [],
-            "compilerPath": "/usr/bin/gcc",
+            "compilerPath": "/home/glenn/.espressif/tools/xtensa-esp-elf/esp-15.2.0_20251204/xtensa-esp32s3-elf/bin/xtensa-esp32s3-elf-gcc",
             "cStandard": "c17",
             "cppStandard": "gnu++17",
             "intelliSenseMode": "linux-clang-x64"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "cmake.sourceDirectory": "/media/glenn/GDE-SSD/projects/esp32-tracker/firmware"
+    "cmake.sourceDirectory": "${workspaceFolder}/firmware"
 }

--- a/firmware/main/battery.cpp
+++ b/firmware/main/battery.cpp
@@ -38,3 +38,39 @@ BatteryDriver::deinit () {
 	}
 	return ESP_OK;
 }
+
+std::optional<uint16_t>
+BatteryDriver::read_voltage_mv () {
+	if (!initialized_) {
+		ESP_LOGW (TAG, "Battery not initialized");
+		return std::nullopt;
+	}
+
+	int raw = 0;
+	esp_err_t err = adc_oneshot_read (adc_handle_, BATTERY_ADC_CHANNEL, &raw);
+	if (err != ESP_OK) {
+		ESP_LOGW (TAG, "ADC read failed: %s", esp_err_to_name (err));
+		return std::nullopt;
+	}
+
+	uint32_t voltage_mv = (uint32_t)raw * BATTERY_ADC_VREF_MV * 2 / BATTERY_ADC_MAX;
+	return (uint16_t)(voltage_mv);
+}
+
+std::optional<uint8_t>
+BatteryDriver::read_percentage () {
+	auto voltage_opt = read_voltage_mv ();
+	if (!voltage_opt) {
+		return std::nullopt;
+	}
+
+	uint16_t voltage = *voltage_opt;
+	if (voltage >= BATTERY_FULL_SCALE_MV) {
+		return 100;
+	}
+	if (voltage <= BATTERY_EMPTY_SCALE_MV) {
+		return 0;
+	}
+	return (uint8_t)((voltage - BATTERY_EMPTY_SCALE_MV) * 100
+					 / (BATTERY_FULL_SCALE_MV - BATTERY_EMPTY_SCALE_MV));
+}

--- a/firmware/main/battery.hpp
+++ b/firmware/main/battery.hpp
@@ -22,7 +22,9 @@ class BatteryDriver {
 	esp_err_t init ();
 	esp_err_t deinit ();
 
+	/// @return Battery voltage in millivolts, or std::nullopt if read failed
 	std::optional<uint16_t> read_voltage_mv ();
+	/// @return Battery percentage (0-100), or std::nullopt if read failed
 	std::optional<uint8_t> read_percentage ();
 
   private:

--- a/firmware/main/battery.hpp
+++ b/firmware/main/battery.hpp
@@ -3,7 +3,8 @@
 #include "esp_adc/adc_oneshot.h"
 #include "esp_err.h"
 #include "esp_log.h"
-#include <stdint.h>
+#include <cstdint>
+#include <optional>
 
 constexpr adc_unit_t BATTERY_ADC_UNIT = ADC_UNIT_1;
 constexpr adc_channel_t BATTERY_ADC_CHANNEL = ADC_CHANNEL_0;
@@ -21,36 +22,8 @@ class BatteryDriver {
 	esp_err_t init ();
 	esp_err_t deinit ();
 
-	uint16_t
-	read_voltage_mv () {
-		if (!initialized_) {
-			ESP_LOGW ("BATTERY", "Battery not initialized");
-			return 0;
-		}
-
-		int raw = 0;
-		esp_err_t err = adc_oneshot_read (adc_handle_, BATTERY_ADC_CHANNEL, &raw);
-		if (err != ESP_OK) {
-			ESP_LOGW ("BATTERY", "ADC read failed: %s", esp_err_to_name (err));
-			return 0;
-		}
-
-		uint32_t voltage_mv = (uint32_t)raw * BATTERY_ADC_VREF_MV * 2 / BATTERY_ADC_MAX;
-		return (uint16_t)(voltage_mv);
-	}
-
-	uint8_t
-	read_percentage () {
-		uint16_t voltage = read_voltage_mv ();
-		if (voltage >= BATTERY_FULL_SCALE_MV) {
-			return 100;
-		}
-		if (voltage <= BATTERY_EMPTY_SCALE_MV) {
-			return 0;
-		}
-		return (uint8_t)((voltage - BATTERY_EMPTY_SCALE_MV) * 100
-						 / (BATTERY_FULL_SCALE_MV - BATTERY_EMPTY_SCALE_MV));
-	}
+	std::optional<uint16_t> read_voltage_mv ();
+	std::optional<uint8_t> read_percentage ();
 
   private:
 	adc_oneshot_unit_handle_t adc_handle_;

--- a/firmware/main/gps.cpp
+++ b/firmware/main/gps.cpp
@@ -10,7 +10,10 @@ static const char* TAG = "gps";
 Gps::Gps (uart_port_t uart_num) : uart_num_ (uart_num), data_ ({}) {}
 
 Gps::~Gps () {
-	uart_driver_delete (uart_num_);
+	esp_err_t err = uart_driver_delete (uart_num_);
+	if (err != ESP_OK) {
+		ESP_LOGW (TAG, "UART driver delete failed: %s", esp_err_to_name (err));
+	}
 }
 
 bool
@@ -22,7 +25,11 @@ Gps::init () {
 		.pull_down_en = GPIO_PULLDOWN_DISABLE,
 		.intr_type = GPIO_INTR_DISABLE,
 	};
-	ESP_ERROR_CHECK (gpio_config (&power_config));
+	esp_err_t err = gpio_config (&power_config);
+	if (err != ESP_OK) {
+		ESP_LOGE (TAG, "GPIO config failed: %s", esp_err_to_name (err));
+		return false;
+	}
 	gpio_set_level (BOARD_GPS_POWER_PIN, 0);
 
 	uart_config_t uart_config = {};

--- a/firmware/main/state_machine.cpp
+++ b/firmware/main/state_machine.cpp
@@ -282,7 +282,7 @@ TrackerStateMachine::try_lora_send (const GpsData& data, bool valid_fix) {
 	int32_t lat = valid_fix ? (int32_t)(data.latitude * 1000000) : 0;
 	int32_t lon = valid_fix ? (int32_t)(data.longitude * 1000000) : 0;
 	int32_t alt = valid_fix ? (int32_t)(data.altitude * 100) : 0;
-	uint8_t battery = battery_.read_percentage ().value_or (255);
+	uint8_t battery = battery_.read_percentage ().value_or (255); // 255 = read error
 	uint8_t flags = valid_fix ? 0x01 : 0x00;
 	uint32_t timestamp = (uint32_t)(esp_timer_get_time () / 1000000);
 

--- a/firmware/main/state_machine.cpp
+++ b/firmware/main/state_machine.cpp
@@ -282,7 +282,7 @@ TrackerStateMachine::try_lora_send (const GpsData& data, bool valid_fix) {
 	int32_t lat = valid_fix ? (int32_t)(data.latitude * 1000000) : 0;
 	int32_t lon = valid_fix ? (int32_t)(data.longitude * 1000000) : 0;
 	int32_t alt = valid_fix ? (int32_t)(data.altitude * 100) : 0;
-	uint16_t battery = battery_.read_percentage ();
+	uint8_t battery = battery_.read_percentage ().value_or (255);
 	uint8_t flags = valid_fix ? 0x01 : 0x00;
 	uint32_t timestamp = (uint32_t)(esp_timer_get_time () / 1000000);
 


### PR DESCRIPTION
## Summary

Address three GitHub issues for improved error handling:

- **Issue #26**: UART cleanup - check return value in `Gps::~Gps()` destructor
- **Issue #27**: GPIO config - graceful error handling instead of `ESP_ERROR_CHECK` in `Gps::init()`
- **Issue #28**: Battery reads - use `std::optional` instead of sentinel values (0, 255)

## Changes

- `gps.cpp`: Check `uart_driver_delete()` return value; replace `ESP_ERROR_CHECK` with proper error handling for `gpio_config()`
- `battery.hpp/cpp`: `read_voltage_mv()` and `read_percentage()` now return `std::optional<T>` instead of using sentinel values
- `state_machine.cpp`: Updated to handle `std::optional` return, using `.value_or(255)` for battery

## Testing

Build passes for ESP32-S3 target.

## Checklist

- [x] Tests pass
- [x] Build succeeds