### PR TITLE
fix: use #pragma pack for BLE structs

### DIFF
--- a/firmware/main/ble.hpp
+++ b/firmware/main/ble.hpp
@@ -20,6 +20,7 @@ constexpr uint16_t BLE_MIN_INTERVAL_MS = 20;
 constexpr uint16_t BLE_MAX_INTERVAL_MS = 40;
 constexpr uint16_t BLE_MUTEX_TIMEOUT_MS = 100;
 
+#pragma pack(push, 1)
 struct BleLocationData {
 	int32_t latitude;
 	int32_t longitude;
@@ -36,6 +37,7 @@ struct BleAlertData {
 	int32_t altitude;
 	uint32_t timestamp;
 };
+#pragma pack(pop)
 
 class BleServer {
   public:


### PR DESCRIPTION
## Summary

Fixes issue #45: BLE struct padding causes serialization corruption

**Problem:** `BleLocationData` and `BleAlertData` structs had alignment padding. When `memcpy` was used to copy these structs, padding bytes were included, sending garbage data over BLE.

**Solution:** Added `#pragma pack(push, 1)` and `#pragma pack(pop)` around struct definitions to ensure deterministic 18-byte (BleAlertData) and 17-byte (BleLocationData) serialization.

## Changes

- `firmware/main/ble.hpp`: Added `#pragma pack(push, 1)` before structs and `#pragma pack(pop)` after

## Testing

Build passes for ESP32-S3 target.