### PR TITLE
fix: replace VLA with std::vector in LoRa driver

### DIFF
--- a/firmware/main/lora/sx1262.cpp
+++ b/firmware/main/lora/sx1262.cpp
@@ -5,6 +5,7 @@
 #include "freertos/event_groups.h"
 #include "freertos/timers.h"
 #include <string.h>
+#include <vector>
 
 static const char* TAG = "sx1262";
 
@@ -425,9 +426,9 @@ LoRaDriver::receive (uint8_t* data, size_t max_len, size_t* actual_len, uint32_t
 		}
 
 		uint8_t cmd = 0x1F;
-		uint8_t rx_data[*actual_len + 1];
-		read_reg (cmd, rx_data, *actual_len + 1);
-		memcpy (data, rx_data + rx_start, *actual_len);
+		std::vector<uint8_t> rx_data (*actual_len + 1);
+		read_reg (cmd, rx_data.data (), *actual_len + 1);
+		memcpy (data, rx_data.data () + rx_start, *actual_len);
 
 		int8_t snr = (int8_t)read_reg (0x1D);
 		int8_t rssi = (int8_t)read_reg (0x1E);


### PR DESCRIPTION
## Summary

Fixes issue #42: VLA (Variable Length Array) in LoRa driver receive()

**Problem:** `receive()` used a C99 VLA: `uint8_t rx_data[*actual_len + 1]` which is dangerous on embedded systems with limited stack space.

**Solution:** Replaced VLA with `std::vector<uint8_t>` which provides dynamic allocation without stack pressure.

## Changes

- `firmware/main/lora/sx1262.cpp`:
  - Added `#include <vector>`
  - Changed `uint8_t rx_data[*actual_len + 1]` to `std::vector<uint8_t> rx_data(*actual_len + 1)`
  - Updated `read_reg` and `memcpy` calls to use `.data()` method

## Notes

- Issue #41 (GPIO resource leak) - Closed as won't-fix: ESP-IDF doesn't require explicit GPIO deallocation
- Issue #43 (wait_busy infinite loop) - Closed as false positive: Code correctly returns `ESP_ERR_TIMEOUT` on timeout

## Testing

Build passes for ESP32-S3 target.