### PR TITLE
fix: add NULL check to nmea_validate_checksum()

### DIFF
--- a/firmware/main/nmea_parser.hpp
+++ b/firmware/main/nmea_parser.hpp
@@ -76,6 +76,9 @@ nmea_parse_field (const char* nmea, int field_idx, char* out, size_t out_len) {
  */
 inline bool
 nmea_validate_checksum (const char* nmea, size_t len) {
+	if (!nmea)
+		return false;
+
 	const char* checksum_ptr = (const char*)memchr (nmea, '*', len);
 	if (!checksum_ptr) {
 		return false;


### PR DESCRIPTION
## Summary

Add guard for NULL `nmea` pointer in `nmea_validate_checksum()` before calling `memchr()` to prevent undefined behavior.

## Changes

- `firmware/main/nmea_parser.hpp`: Add `if (!nmea) return false;` at start of function

## Testing

- Host tests pass
- Build passes

Closes #60