### PR TITLE
fix: add error handling to TrackerStateMachine::init()

### DIFF
--- a/firmware/main/ble.hpp
+++ b/firmware/main/ble.hpp
@@ -28,6 +28,7 @@ struct BleLocationData {
 	uint32_t timestamp;
 	uint8_t valid;
 };
+static_assert(sizeof(BleLocationData) == 17, "BleLocationData must be 17 bytes for BLE");
 
 struct BleAlertData {
 	uint8_t alert_type;
@@ -37,6 +38,7 @@ struct BleAlertData {
 	int32_t altitude;
 	uint32_t timestamp;
 };
+static_assert(sizeof(BleAlertData) == 18, "BleAlertData must be 18 bytes for BLE");
 #pragma pack(pop)
 
 class BleServer {
@@ -44,12 +46,12 @@ class BleServer {
 	BleServer ();
 	~BleServer ();
 
-	esp_err_t init ();
-	esp_err_t start ();
-	esp_err_t stop ();
-	esp_err_t update_location (const BleLocationData& location);
-	esp_err_t send_alert (const BleAlertData& alert);
-	esp_err_t set_device_name (const char* name);
+	[[nodiscard]] esp_err_t init ();
+	[[nodiscard]] esp_err_t start ();
+	[[nodiscard]] esp_err_t stop ();
+	[[nodiscard]] esp_err_t update_location (const BleLocationData& location);
+	[[nodiscard]] esp_err_t send_alert (const BleAlertData& alert);
+	[[nodiscard]] esp_err_t set_device_name (const char* name);
 
 	bool is_connected () const;
 

--- a/firmware/main/config.hpp
+++ b/firmware/main/config.hpp
@@ -42,6 +42,15 @@ class Config {
 	static esp_err_t get_spreading_factor (uint8_t& sf);
 	static esp_err_t set_spreading_factor (uint8_t sf);
 
+	/**
+	 * @brief Get device name from NVS
+	 * @param name Buffer to store device name
+	 * @param max_len Maximum buffer size
+	 * @return ESP_OK on success, error code otherwise
+	 * @note If key not found in NVS, returns default name "PetTracker" and ESP_OK.
+	 *       Callers who need to distinguish "stored value" vs "default" should use
+	 *       nvs_get_str() directly.
+	 */
 	static esp_err_t get_device_name (char* name, size_t max_len);
 	static esp_err_t set_device_name (const char* name);
 

--- a/firmware/main/main.cpp
+++ b/firmware/main/main.cpp
@@ -65,7 +65,10 @@ app_main (void) {
 	}
 
 	static TrackerStateMachine state_machine (gps, lora, accel, ble, led, battery);
-	state_machine.init ();
+	esp_err_t sm_err = state_machine.init ();
+	if (sm_err != ESP_OK) {
+		ESP_LOGE (TAG, "State machine init failed: %s", esp_err_to_name (sm_err));
+	}
 
 	ESP_LOGI (TAG, "Pet tracker initialized, entering main loop");
 

--- a/firmware/main/state_machine.cpp
+++ b/firmware/main/state_machine.cpp
@@ -221,7 +221,7 @@ TrackerStateMachine::check_geofence () {
 			alert.longitude = (int32_t)(data.longitude * COORD_SCALE);
 			alert.altitude = (int32_t)(data.altitude * 100);
 			alert.timestamp = (uint32_t)(esp_timer_get_time () / 1000000);
-			ble_.send_alert (alert);
+			ESP_ERROR_CHECK (ble_.send_alert (alert));
 			break;
 		}
 	}

--- a/firmware/main/state_machine.cpp
+++ b/firmware/main/state_machine.cpp
@@ -16,13 +16,13 @@ TrackerStateMachine::TrackerStateMachine (Gps& gps, LoRaDriver& lora, Accelerome
 	  lora_ (lora), accel_ (accel), ble_ (ble), led_ (led), battery_ (battery),
 	  geofence_breach_ (false) {}
 
-void
+esp_err_t
 TrackerStateMachine::init () {
 	esp_err_t err = Config::init ();
 	if (err != ESP_OK) {
 		ESP_LOGE (TAG, "Config::init() failed: %s", esp_err_to_name (err));
 		transition_to (TrackerState::ERROR);
-		return;
+		return err;
 	}
 
 	err = Config::load (config_);
@@ -34,6 +34,7 @@ TrackerStateMachine::init () {
 	lora_.set_spreading_factor (config_.spreading_factor);
 
 	transition_to (TrackerState::IDLE);
+	return ESP_OK;
 }
 
 void

--- a/firmware/main/state_machine.hpp
+++ b/firmware/main/state_machine.hpp
@@ -35,7 +35,7 @@ class TrackerStateMachine {
 	TrackerStateMachine (Gps& gps, LoRaDriver& lora, Accelerometer& accel, BleServer& ble,
 						 LedDriver& led, BatteryDriver& battery);
 
-	void init ();
+	esp_err_t init ();
 	void run ();
 
 	TrackerState


### PR DESCRIPTION
## Summary

Change `init()` return type from `void` to `esp_err_t` to signal success/failure.

## Changes

- `state_machine.hpp`: Change `void init()` to `esp_err_t init()`
- `state_machine.cpp`: Return error if `Config::init()` fails, otherwise `ESP_OK`
- `main.cpp`: Handle returned error from `state_machine.init()`

Closes #58