### PR TITLE
docs: document LED init cannot fail (closes #59 as won't fix)

### DIFF
--- a/firmware/main/led_driver.hpp
+++ b/firmware/main/led_driver.hpp
@@ -9,7 +9,9 @@ class LedDriver : public GpioDriver {
   public:
 	/**
 	 * @brief Construct a LedDriver
-	 * @param pin GPIO pin connected to LED
+	 * @param pin GPIO pin connected to LED (must be valid board GPIO)
+	 * @note Construction cannot fail - pin is validated at compile time via board_config.h.
+	 *       LED init is purely runtime GPIO configuration which ESP-IDF guarantees success.
 	 */
 	LedDriver (gpio_num_t pin);
 


### PR DESCRIPTION
## Summary

Document that LED initialization cannot fail (per issue #59 decision).

## Rationale

LED GPIO pin is defined as a constant (`BOARD_LED_PIN`) in `board_config.h`, not runtime configurable. The constructor calls the parent `GpioDriver` which configures GPIO mode - ESP-IDF guarantees success for valid GPIO pins.

Therefore, error handling for LED init is unnecessary. This PR documents the rationale in the header.

**Closes #59 as won't-fix** - LED is non-critical for tracker operation, and init cannot fail for valid board pins.